### PR TITLE
Update make theo for missing cropping

### DIFF
--- a/R/make_binary_ParameterTable.R
+++ b/R/make_binary_ParameterTable.R
@@ -1,0 +1,92 @@
+#' Makes a version of the Grambank ParameterTable with information on binarised features
+#' @param ParameterTable data-frame, long format. ParameterTable from cldf.
+#' @param keep_multi_state_features logical. If TRUE, rows with the multistate version of the features remain, if FALSE only binary or binarised features remain in the ParameterTable.
+#' @return data-frame of ParameterTable with added rows for binarised version of multi-state features
+#' @export
+
+make_binary_ParameterTable<- function(ParameterTable,
+                                      keep_multi_state_features = TRUE){
+
+#ParameterTable <- grambank_cldf_object $tables$ParameterTable
+
+Parameter_binary <- data.frame(
+    ID = c(
+        "G024", "G024",
+        "G025", "G025",
+        "G065", "G065",
+        "G130","G130",
+        "G193","G193",
+        "G203", "G203"
+    ),
+
+        ID_binary = c(
+        "GB024a", "GB024b",
+        "GB025a", "GB025b",
+        "GB065a", "GB065b",
+        "GB130a","GB130b",
+        "GB193a","GB193b",
+        "GB203a", "GB203b"
+    ),
+    Grambank_ID_desc_binary = c(
+        "GB024a NUMOrder_Num-N",
+        "GB024b NUMOrder_N-Num",
+        "GB025a DEMOrder_Dem-N",
+        "GB025b DEMOrder_N-Dem",
+        "GB065a POSSOrder_PSR-PSD",
+        "GB065b POSSOrder_PSD-PSR",
+        "GB130a IntransOrder_SV",
+        "GB130b IntransOrder_VS",
+        "GB193a ANMOrder_ANM-N",
+        "GB193b ANMOrder_N-ANM",
+        "GB203a UQOrder_UQ-N",
+        "GB203b UQOrder_N-UQ"
+    ),
+    Name_binary = c("Is the order of the numeral and noun Num-N?",
+             "Is the order of the numeral and noun N-Num?",
+             "Is the order of the adnominal demonstrative and noun Dem-N?",
+             "Is the order of the adnominal demonstrative and noun N-Dem?",
+             "Is the pragmatically unmarked order of adnominal possessor noun and possessed noun PSR-PSD?",
+             "Is the pragmatically unmarked order of adnominal possessor noun and possessed noun PSD-PSR?",
+             "Is the pragmatically unmarked order of S and V in intransitive clauses S-V?",
+             "Is the pragmatically unmarked order of S and V in intransitive clauses V-S?",
+             "Is the order of the adnominal property word (ANM) and noun ANM-N?",
+             "Is the order of the adnominal property word (ANM) and noun N-ANM?",
+             "Is the order of the adnominal collective universal quantifier (UQ) and noun UQ-N?",
+             "Is the order of the adnominal collective universal quantifier (UQ) and noun N-QU?" ),
+
+    "Word_Order_binary"= c(
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        NA,
+        NA,
+        0,
+        1,
+        0,
+        1
+    ),
+    Binary_Multistate = c("Binarised","Binarised","Binarised","Binarised","Binarised","Binarised","Binarised","Binarised","Binarised","Binarised","Binarised","Binarised"))
+
+
+multistate_features <- c("GB024", "GB025", "GB065", "GB130", "GB193", "GB203")
+
+ParameterTable_new <- ParameterTable %>%
+    full_join(Parameter_binary, by = "ID") %>%
+    mutate(ID = ifelse(!is.na(ID_binary), ID_binary, ID)) %>%
+    mutate(Name = ifelse(!is.na(Name_binary), Name_binary, Name)) %>%
+    mutate(Grambank_ID_desc = ifelse(!is.na(Grambank_ID_desc_binary), Grambank_ID_desc_binary, Grambank_ID_desc)) %>%
+    mutate(Word_Order = ifelse(!is.na(Word_Order_binary), Word_Order_binary, Word_Order)) %>%
+    dplyr::select(-c("ID_binary", Name_binary, Grambank_ID_desc_binary, Word_Order_binary)) %>%
+    mutate(Binary_Multistate= ifelse(ID %in% multistate_features, "Multi", Binary_Multistate)) %>%
+    mutate(Binary_Multistate = ifelse(is.na(Binary_Multistate), "Binary", Binary_Multistate))
+
+if(keep_multi_state_features == FALSE){
+ParameterTable_new <-     ParameterTable_new %>%
+    filter(!(ID %in% multistate_features))
+}
+
+ParameterTable_new
+}

--- a/R/make_theo_scores.R
+++ b/R/make_theo_scores.R
@@ -47,7 +47,7 @@ make_theo_scores <- function(ValueTable,
         dplyr::mutate(Value_weighted = ifelse(Fusion == 0.5 & Value == 1, 0.5, Value )) %>%
         # replacing all instances of 1 for a feature that is weighted to 0.5 bound morph points to 0.5
         dplyr::group_by(Language_ID) %>%
-        dplyr::summarise(mean_morph = mean(Value_weighted))
+        dplyr::summarise(Fusion = mean(Value_weighted))
 
     ##Flexivity scores
     lg_df_for_flex_count <- ValueTable  %>%

--- a/R/make_theo_scores.R
+++ b/R/make_theo_scores.R
@@ -1,19 +1,29 @@
 #' Computes scores based on theoretical linguistics on grambank data.
 #'
-#' @param ValueTable_binary a data-frame, long format, of Grambank values - binarised. Use rgrambank::binarise().
-#' @param ParameterTable_binary data-frame of Grambank ParameterTable - binarised. Use rgrambank::make_binary_ParameterTable.
+#' @param ValueTable data-frame, long format, of Grambank values. If not already binarised, rgrambank::binarise() will be applied.
+#' @param ParameterTable data-frame of Grambank ParameterTable. . If not already binarised, rgrambank::make_binary_ParameterTable will be applied.
 #' @param missing_cut_off numeric value between 0 and 1 representing cut-off for how much coverage each language should have, for each feature set. For each set of features for the theoretical scores, if a language falls under the threshold, it is not considered for the theoretical score (but may be considered for other sets). 0.75 means that languages with 75% of feature values non-missing for that set of features are included, less than 75% coverage are dropped.
 #' @return A data-frame with theoretical scores per language.
 #' @export
-make_theo_scores <- function(ValueTable_binary,
-                             ParameterTable_binary,
+make_theo_scores <- function(ValueTable,
+                             ParameterTable,
                              missing_cut_off = 0.75){
 
 #    grambank_cldf_object <- rcldf::cldf(mdpath = "https://zenodo.org/records/7844558/files/grambank/grambank-v1.0.3.zip",load_bib = FALSE)
 #   source("R/make_binary_ParameterTable.R")
 #   source("R/binarise.R")
-#    ValueTable <- grambank_cldf_object $tables$ValueTable %>% binarise()
-#    ParameterTable <- grambank_cldf_object $tables$ParameterTable %>% make_binary_ParameterTable()
+#   library(tidyverse)
+
+#ValueTable <-   grambank_cldf_object$tables$ValueTable
+#ParameterTable <-   grambank_cldf_object$tables$ParameterTable
+
+if("GB203b" %in% ValueTable$Parameter_ID){
+        ValueTable <- ValueTable %>% rgrambank::binarise()
+}
+
+if("GB203b" %in% ParameterTable$ID){
+    ParameterTable <- ParameterTable %>% rgrambank::make_binary_ParameterTable()
+}
 
     #read in sheet with scores for whether a feature denotes fusion
     ParameterTable <- ParameterTable %>%

--- a/R/make_theo_scores.R
+++ b/R/make_theo_scores.R
@@ -1,32 +1,49 @@
 #' Computes scores based on theoretical linguistics on grambank data.
 #'
 #' @param ValueTable a data-frame, long format, of Grambank values
-#' @param ParameterTable data-frame of Grambank ParameterTable. If there is problems reading in the csv-file into R, see rcldf::cldf().
+#' @param ParameterTable_binary data-frame of Grambank ParameterTable - binarised. Use rgrambank::make_binary_ParameterTable.
+#' @param missing_cut_off numeric value between 0 and 1 representing cut-off for how much coverage each language should have. For each set of features for the theoretical scores, if a language falls under the threshold, it is not considered for the theoretical score.
 #' @return A data-frame with theoretical scores per language.
 #' @export
-make_theo_scores <- function(ValueTable, ParameterTable){
+make_theo_scores <- function(ValueTable,
+                             ParameterTable,
+                             missing_cut_off = 0.75){
+
+#    grambank_cldf_object <- rcldf::cldf(mdpath = "https://zenodo.org/records/7844558/files/grambank/grambank-v1.0.3.zip",load_bib = FALSE)
+#   source("R/make_binary_ParameterTable.R")
+#    ValueTable <- grambank_cldf_object $tables$ValueTable
+#    ParameterTable <- grambank_cldf_object $tables$ParameterTable %>% make_binary_ParameterTable()
 
     #read in sheet with scores for whether a feature denotes fusion
     ParameterTable <- ParameterTable %>%
         dplyr::select(Parameter_ID = ID, Fusion = Boundness, Informativity, Locus_of_Marking, Word_Order, Gender_or_Noun_Class, Flexivity) %>%
         dplyr::mutate(Fusion = as.numeric(Fusion)) %>%
+        dplyr::mutate(Fusion = ifelse(Fusion == 0, NA, Fusion)) %>%
         dplyr::mutate(Gender_or_Noun_Class = as.numeric(Gender_or_Noun_Class)) %>%
         dplyr::mutate(Flexivity = as.numeric(Flexivity)) %>%
         dplyr::mutate(Locus_of_Marking = as.numeric(Locus_of_Marking)) %>%
         dplyr::mutate(Word_Order = as.numeric(Word_Order))
 
-    # remove features for which there is only a feature for the free or bound
-    # kind of marking, only keep those where there is one for each type of
-    # marking
+    n_fusion_feats <- length(ParameterTable$Fusion %>% na.omit())
+    n_informativity_feats <- length(ParameterTable$Informativity %>% na.omit())
+    n_gender_NC_feats <- length(ParameterTable$Gender_or_Noun_Class %>% na.omit())
+    n_flexivity_feats <- length(ParameterTable$Flexivity %>% na.omit())
+    n_locus_marking_feats <- length(ParameterTable$Locus_of_Marking %>% na.omit())
+    n_word_order_feats <- length(ParameterTable$Word_Order %>% na.omit())
+
     ValueTable <- ValueTable %>%
         dplyr::inner_join(ParameterTable , by = "Parameter_ID") %>%
         dplyr::filter(!is.na(Value)) %>%
-        dplyr::filter(Value != "?") %>% 
+        dplyr::filter(Value != "?") %>%
         dplyr::mutate(Value = as.numeric(Value))  # drop out ? marking and makes it possible to sum, mean etc
 
     #fusion counts
     lg_df_for_fusion_count <- ValueTable %>%
+        dplyr::filter(!is.na(Fusion)) %>%
         dplyr::filter(Fusion != 0) %>%
+        group_by(Language_ID) %>%
+        mutate(n = n()) %>%
+        filter(n >= n_fusion_feats * missing_cut_off) %>%
         dplyr::mutate(Value_weighted = ifelse(Fusion == 0.5 & Value == 1, 0.5, Value )) %>%
         # replacing all instances of 1 for a feature that is weighted to 0.5 bound morph points to 0.5
         dplyr::group_by(Language_ID) %>%
@@ -35,6 +52,9 @@ make_theo_scores <- function(ValueTable, ParameterTable){
     ##Flexivity scores
     lg_df_for_flex_count <- ValueTable  %>%
         dplyr::filter(!is.na(Flexivity)) %>%
+        group_by(Language_ID) %>%
+        mutate(n = n()) %>%
+        filter(n >= n_flexivity_feats * missing_cut_off) %>%
         # reversing the Values of the features that have a score of 0
         dplyr::mutate(Value_weighted = ifelse(Flexivity == 0, abs(Value-1), Value)) %>%
         dplyr::group_by(Language_ID) %>%
@@ -43,6 +63,9 @@ make_theo_scores <- function(ValueTable, ParameterTable){
     ##`locus of marking`s
     lg_df_for_HM_DM_count <- ValueTable %>%
         dplyr::filter(!is.na(Locus_of_Marking)) %>%
+        group_by(Language_ID) %>%
+        mutate(n = n()) %>%
+        filter(n >= n_locus_marking_feats * missing_cut_off) %>%
         # reversing the Values of the features that have a score of 0
         dplyr::mutate(Value_weighted = ifelse(Locus_of_Marking == 0, abs(Value-1), Value)) %>%
         dplyr::group_by(Language_ID) %>%
@@ -51,6 +74,9 @@ make_theo_scores <- function(ValueTable, ParameterTable){
     ##Gender_or_Noun_Class scores
     lg_df_for_gender_nc_count <- ValueTable  %>%
         dplyr::filter(!is.na(Gender_or_Noun_Class)) %>%
+        group_by(Language_ID) %>%
+        mutate(n = n()) %>%
+        filter(n >= n_gender_NC_feats * missing_cut_off) %>%
         # reversing the Values of the features that have a score of 0
         dplyr::mutate(Value_weighted = ifelse(Gender_or_Noun_Class == 0, abs(Value-1), Value)) %>%
         dplyr::group_by(Language_ID) %>%
@@ -59,7 +85,9 @@ make_theo_scores <- function(ValueTable, ParameterTable){
      ##OV_VO scores
      lg_df_for_OV_VO_count <- ValueTable  %>%
          dplyr::filter(!is.na(Word_Order)) %>%
-         # reversing the Values of the features that refer to free-standing markers
+         group_by(Language_ID) %>%
+         mutate(n = n()) %>%
+         filter(n >= n_word_order_feats * missing_cut_off) %>%
          dplyr::mutate(Value_weighted = ifelse(Word_Order == 0, abs(Value-1), Value)) %>%
          dplyr::group_by(Language_ID) %>%
          dplyr::summarise(Word_Order = mean(Value_weighted), .groups = "drop_last")
@@ -67,6 +95,9 @@ make_theo_scores <- function(ValueTable, ParameterTable){
     ##informativity score
     lg_df_informativity_score <-  ValueTable  %>%
         dplyr::filter(!is.na(Informativity)) %>%
+        group_by(Language_ID) %>%
+        mutate(n = n()) %>%
+        filter(n >= n_informativity_feats * missing_cut_off) %>%
         # reversing GB140 because 0 is the informative state
         dplyr::mutate(Value = ifelse(Parameter_ID == "GB140", abs(Value-1), Value)) %>%
         #grouping per language and per informativity category
@@ -75,14 +106,14 @@ make_theo_scores <- function(ValueTable, ParameterTable){
         # .. how many are answered 1 ("yes")
         # how many of the Values per informativity category are missing
         dplyr::summarise(
-            sum_informativity = sum(Value, na.rm = TRUE), sum_na = sum(is.na(Value)), .groups = "drop_last" ) %>%
+            sum_informativity = sum(Value), sum_na = sum(is.na(Value)), .groups = "drop_last" ) %>%
         # if there is at least one NA and the sum of Values for the entire category is 0, the
         # informativity score should be NA because there could be a 1 hiding under the NA Value.
         dplyr::mutate(sum_informativity = ifelse(sum_na >= 1 & sum_informativity == 0, NA, sum_informativity)) %>%
         dplyr::mutate(informativity_score = ifelse(sum_informativity >= 1, 1, sum_informativity)) %>%
         dplyr::ungroup() %>%
         dplyr::group_by(Language_ID) %>%
-        dplyr::summarise(Informativity = mean(informativity_score, na.rm = TRUE), .groups = "drop_last")
+        dplyr::summarise(Informativity = mean(informativity_score), .groups = "drop_last")
 
     lg_df_for_OV_VO_count %>%
         dplyr::full_join(lg_df_for_flex_count, by = "Language_ID") %>%

--- a/R/make_theo_scores.R
+++ b/R/make_theo_scores.R
@@ -1,17 +1,18 @@
 #' Computes scores based on theoretical linguistics on grambank data.
 #'
-#' @param ValueTable a data-frame, long format, of Grambank values
+#' @param ValueTable_binary a data-frame, long format, of Grambank values - binarised. Use rgrambank::binarise().
 #' @param ParameterTable_binary data-frame of Grambank ParameterTable - binarised. Use rgrambank::make_binary_ParameterTable.
 #' @param missing_cut_off numeric value between 0 and 1 representing cut-off for how much coverage each language should have. For each set of features for the theoretical scores, if a language falls under the threshold, it is not considered for the theoretical score. 0.75 means that languages with 75% of feature values non-missing for that set of features are included, less than 75% coverage are dropped.
 #' @return A data-frame with theoretical scores per language.
 #' @export
-make_theo_scores <- function(ValueTable,
-                             ParameterTable,
+make_theo_scores <- function(ValueTable_binary,
+                             ParameterTable_binary,
                              missing_cut_off = 0.75){
 
 #    grambank_cldf_object <- rcldf::cldf(mdpath = "https://zenodo.org/records/7844558/files/grambank/grambank-v1.0.3.zip",load_bib = FALSE)
 #   source("R/make_binary_ParameterTable.R")
-#    ValueTable <- grambank_cldf_object $tables$ValueTable
+#   source("R/binarise.R")
+#    ValueTable <- grambank_cldf_object $tables$ValueTable %>% binarise()
 #    ParameterTable <- grambank_cldf_object $tables$ParameterTable %>% make_binary_ParameterTable()
 
     #read in sheet with scores for whether a feature denotes fusion
@@ -120,7 +121,7 @@ make_theo_scores <- function(ValueTable,
         dplyr::full_join(lg_df_for_gender_nc_count, by = "Language_ID") %>%
         dplyr::full_join(lg_df_for_HM_DM_count, by = "Language_ID") %>%
         dplyr::full_join(lg_df_for_fusion_count, by = "Language_ID") %>%
-        dplyr::full_join(lg_df_informativity_score, by = "Language_ID")
+        dplyr::full_join(lg_df_informativity_score, by = "Language_ID") %>%
 }
 
 

--- a/R/make_theo_scores.R
+++ b/R/make_theo_scores.R
@@ -2,7 +2,7 @@
 #'
 #' @param ValueTable a data-frame, long format, of Grambank values
 #' @param ParameterTable_binary data-frame of Grambank ParameterTable - binarised. Use rgrambank::make_binary_ParameterTable.
-#' @param missing_cut_off numeric value between 0 and 1 representing cut-off for how much coverage each language should have. For each set of features for the theoretical scores, if a language falls under the threshold, it is not considered for the theoretical score.
+#' @param missing_cut_off numeric value between 0 and 1 representing cut-off for how much coverage each language should have. For each set of features for the theoretical scores, if a language falls under the threshold, it is not considered for the theoretical score. 0.75 means that languages with 75% of feature values non-missing for that set of features are included, less than 75% coverage are dropped.
 #' @return A data-frame with theoretical scores per language.
 #' @export
 make_theo_scores <- function(ValueTable,

--- a/R/make_theo_scores.R
+++ b/R/make_theo_scores.R
@@ -2,7 +2,7 @@
 #'
 #' @param ValueTable_binary a data-frame, long format, of Grambank values - binarised. Use rgrambank::binarise().
 #' @param ParameterTable_binary data-frame of Grambank ParameterTable - binarised. Use rgrambank::make_binary_ParameterTable.
-#' @param missing_cut_off numeric value between 0 and 1 representing cut-off for how much coverage each language should have. For each set of features for the theoretical scores, if a language falls under the threshold, it is not considered for the theoretical score. 0.75 means that languages with 75% of feature values non-missing for that set of features are included, less than 75% coverage are dropped.
+#' @param missing_cut_off numeric value between 0 and 1 representing cut-off for how much coverage each language should have, for each feature set. For each set of features for the theoretical scores, if a language falls under the threshold, it is not considered for the theoretical score (but may be considered for other sets). 0.75 means that languages with 75% of feature values non-missing for that set of features are included, less than 75% coverage are dropped.
 #' @return A data-frame with theoretical scores per language.
 #' @export
 make_theo_scores <- function(ValueTable_binary,

--- a/R/make_theo_scores.R
+++ b/R/make_theo_scores.R
@@ -121,7 +121,7 @@ make_theo_scores <- function(ValueTable_binary,
         dplyr::full_join(lg_df_for_gender_nc_count, by = "Language_ID") %>%
         dplyr::full_join(lg_df_for_HM_DM_count, by = "Language_ID") %>%
         dplyr::full_join(lg_df_for_fusion_count, by = "Language_ID") %>%
-        dplyr::full_join(lg_df_informativity_score, by = "Language_ID") %>%
+        dplyr::full_join(lg_df_informativity_score, by = "Language_ID")
 }
 
 


### PR DESCRIPTION
1) in the grambank-analysed script workflow, we worked a lot with the binarised version of the ParameterTable, which contains crucial data for the word order theo score. When breaking it down into singular functions for the package, I missed this detail and have now remedied it

2) I've implemented an argument to make_theo_scores that defines a cut-off for data coverage that is defined for each set of features for the theo scores, instead of overall for the entire dataset. i.e. if for specifically the features that have to do with fusion there is 60% coverage and the cut-off is 75% that language is dropped.